### PR TITLE
Fix Linux compile error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # AlgorithmsPTGr05
 Repo for university project (homework)-Algorithms Group5
+
+Programs should compile on Linux using the following flags:
+
+```bash
+g++ -std=c++14 -Werror -Wall -Wextra -DNDEBUG -O3 -pedantic something.cpp
+```

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Programs should compile on Linux using the following flags:
 ```bash
 g++ -std=c++14 -Werror -Wall -Wextra -DNDEBUG -O3 -pedantic something.cpp
 ```
+
+Note: Remove the -W flags during development to reduce pain

--- a/assign01/assign01.cpp
+++ b/assign01/assign01.cpp
@@ -59,7 +59,7 @@ void Graph::dijkstra(int src)
 		  list< pair<int, int> >::iterator checkVertex;
 		  checkVertex = adj[selectedVertex].begin();
 
-		  for(checkVertex; checkVertex != adj[selectedVertex].end(); ++checkVertex)
+		  for( ; checkVertex != adj[selectedVertex].end(); ++checkVertex)
 		  {
 			  int checkVertexWeight = (*checkVertex).second;
 			  int checkVertexLabel = (*checkVertex).first;


### PR DESCRIPTION
Commit contains the reason, but to be pedantic:

g++ gives "expression result unused" at compile time at this line; we are incorrectly providing the first part of the for loop. this fixes that. 